### PR TITLE
update: searchForm表单项配置

### DIFF
--- a/docs/changeLog.md
+++ b/docs/changeLog.md
@@ -13,6 +13,9 @@ title: 更新日志
 - TablePage
   - 新增属性 alertNodes
 
+- SearchForm
+  - columns 修改 visible -> enableSearch，新增order，与`tablePage`同步
+
 ### 🚀 2.5.2
 
 `2021-02-25`

--- a/docs/components/search-form.md
+++ b/docs/components/search-form.md
@@ -185,7 +185,8 @@ export default () => {
 |component|Form.Item 的子元素|ReactNode|Input|
 |formItemProps|表单项的属性|Object|-|
 |inputProps|当component不存在时，可以对 Input 进行描述|Object|-|
-|visible|字段是否可见|Boolean|true|
+|enableSearch|字段是否可搜索|Boolean|true|
+|order|字段排序|number|-|
 
 ### callback(type, values)
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "eslint-config-prettier": "^2.9.0",
     "eslint-plugin-babel": "^4.0.0",
     "eslint-plugin-compat": "^2.1.0",
+    "eslint-plugin-html": "^6.1.1",
     "eslint-plugin-import": "^2.8.0",
     "eslint-plugin-jsx-a11y": "^6.0.3",
     "eslint-plugin-markdown": "^1.0.0-beta.6",

--- a/src/search-form/index.js
+++ b/src/search-form/index.js
@@ -13,7 +13,7 @@ export default forwardRef((props, ref) => {
   } = props;
   const [form] = Form.useForm();
   const [collapse, setCollapse] = useState(defaultCollapse);
-  const nowColumns = columns.filter(({ visible = true }) => visible);
+  const nowColumns = columns.filter(({ enableSearch = true }) => enableSearch).sort((a, b) => a.order - b.order);
 
   useImperativeHandle(ref, () => ({ form, reset }));
 


### PR DESCRIPTION
- 与`tablePage`组件的`columns`配置同步，区别是`searchForm`的`enableSearch`默认为`true`